### PR TITLE
Normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Enforce "unix-style" LF line endings, even on Windows (where CRLF is used)